### PR TITLE
Fix module exports

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,1 +1,1 @@
-export default "test-file-stub";
+module.exports = "test-file-stub";

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,1 +1,1 @@
-export default {};
+module.exports = {};

--- a/__mocks__/svgMock.js
+++ b/__mocks__/svgMock.js
@@ -1,1 +1,1 @@
-export default "SvgMock";
+module.exports = "SvgMock";

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,7 @@
-export default function (api) {
+module.exports = function (api) {
   api.cache(true);
   return {
     presets: ["babel-preset-expo"],
     plugins: ["react-native-reanimated/plugin"],
   };
-}
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   preset: "react-native",
   setupFiles: ["./jest.setup.js"],
   setupFilesAfterEnv: ["@testing-library/jest-native/extend-expect"],


### PR DESCRIPTION
This pull request standardizes the module export syntax across the codebase by replacing `export default` with `module.exports`. This change ensures consistency and aligns with CommonJS module standards.

Standardization of module export syntax:

* [`__mocks__/fileMock.js`](diffhunk://#diff-e93266e20048d3387945e2b45c5e8eecfeeedb783dfd9a642d78b2c09f7ddd3bL1-R1): Replaced `export default` with `module.exports` for exporting the file mock.
* [`__mocks__/styleMock.js`](diffhunk://#diff-893eaa0434790df8003af1258a59ffdc1a10f9b9ed7dacde3d4ab3d25a099163L1-R1): Replaced `export default` with `module.exports` for exporting the style mock.
* [`__mocks__/svgMock.js`](diffhunk://#diff-462952e87f2bb80523157e3954a059a8011a7f0afd47729add78fa24df41e187L1-R1): Replaced `export default` with `module.exports` for exporting the SVG mock.
* [`babel.config.js`](diffhunk://#diff-09c56b2bf95de2a608a36afef3b6893146a959d6739be0a154dc9c9f02d80f24L1-R7): Updated the export syntax to use `module.exports` for the Babel configuration function.